### PR TITLE
Fix YAMLLoadWarning #3

### DIFF
--- a/docker_auto_labels/docker_auto_labels.py
+++ b/docker_auto_labels/docker_auto_labels.py
@@ -13,7 +13,7 @@ from docker.models.nodes import Node  # noqa
 def get_content(file_name):
     abs_file_name = os.path.abspath(file_name)
     with open(abs_file_name) as docker_file:
-        return yaml.load(docker_file)
+        return yaml.safe_load(docker_file)
 
 
 def get_existing_labels(nodes):


### PR DESCRIPTION
- Before the fix, the following error occurs with PyYaml 6.0: 
`TypeError: load() missing 1 required positional argument: 'Loader'`

- Reference:
[This page explains the PyYAML 5.1+ deprecation of the plain yaml.load(input) function.](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation)

- An alternative is to specify the version of PyYaml < 5.1.