### PR TITLE
fix: downgrade pyyaml to 5.4.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.md') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-requirements = ['Click>=6.0', 'docker', 'pyyaml']
+requirements = ['Click>=6.0', 'docker', 'pyyaml==5.4.1']
 
 setup_requirements = ['pytest-runner']
 


### PR DESCRIPTION
Docker Auto Labels version: 0.2.3
Python version: 3.10
Operating System: MacOS Ventura 13.1
Description
pyyaml version did match with the way it is used here

What I Did

```bash
$ docker-auto-labels docker-stack.yml 
Traceback (most recent call last):
  File "/opt/homebrew/bin/docker-auto-labels", line 8, in <module>
    sys.exit(main())
  File "/opt/homebrew/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/opt/homebrew/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/opt/homebrew/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/homebrew/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/opt/homebrew/lib/python3.10/site-packages/docker_auto_labels/cli.py", line 25, in main
    docker_auto_labels.process(docker_file_path)
  File "/opt/homebrew/lib/python3.10/site-packages/docker_auto_labels/docker_auto_labels.py", line 82, in process
    content = get_content(file_name)
  File "/opt/homebrew/lib/python3.10/site-packages/docker_auto_labels/docker_auto_labels.py", line 16, in get_content
    return yaml.load(docker_file)
TypeError: load() missing 1 required positional argument: 'Loader'
```

Solution:
Installing 5.4.1 version of pyyaml solved the problem. 
